### PR TITLE
Make comm receiver non-blocking

### DIFF
--- a/comm/comm.cpp
+++ b/comm/comm.cpp
@@ -108,7 +108,7 @@ void Comm::receive()
         }
         cdebug("receive finish");
     }
-    else
+    else if (received < 0)
     {
         tprintf("WARNING: receive failed (returned %d)", received);
     }
@@ -120,6 +120,7 @@ void Comm::receiver()
     {
         receive(); // blocking
     }
+    tprintf("INFO: receiver finished");
 }
 
 void Comm::transmit()

--- a/test/test_clients.cpp
+++ b/test/test_clients.cpp
@@ -278,10 +278,11 @@ int main(int argc, char **argv)
         }
     }
     Comm::shutdown();
-    usleep(100000);
-    // TODO: Shutdown blocks on receiver thread in comm
-    // t1.join();
-    // t2.join();
+    // wait for all threads to finish
+    for (std::vector<boost::thread>::iterator it = threads.begin(); it != threads.end(); ++it)
+    {
+        it->join();
+    }
 
     // done
     return 0;


### PR DESCRIPTION
Makes comm receiver non-blocking. Allows threads to finish when globalShutdown is requested.
Single Ctrl-C now suffices to stop the comm process.